### PR TITLE
Feature/kazuhiro f add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# bin/の実行ファイルは除外
+/bin/*


### PR DESCRIPTION
# 概要

bin/の実行ファイルがgitで追跡されているため、.gitignoreを追加して除外した。

なお、.gitignoreは[GitHubのテンプレート](https://github.com/github/gitignore/blob/master/Go.gitignore)を参考にした。