### PR TITLE
Feature/kazuhiro f improve container settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,55 +1,24 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/docker-existing-docker-compose
-// If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
-	"name": "Existing Docker Compose (Extend)",
-
-	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
-	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"name": "Clubhook-backend",
 	"dockerComposeFile": [
 		"../docker-compose.yml",
 		"docker-compose.yml"
 	],
-
-	// The 'service' property is the name of the service for the container that VS Code should
-	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "app",
-
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/go/src/github.com/kougakusai/clubhook-backend",
-
-	// Set *default* container specific settings.json values on container create.
+	"workspaceFolder": "/go/src/app",
 	"settings": {
+		"[go]": {
+			"editor.insertSpaces": false,
+			"editor.formatOnSave": true
+		},
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.toolsManagement.checkForUpdates": "off",
-		"go.formatTool": "gofmt",
-		"go.lintTool": "golint",
-		"go.gopath": "/go",
-		"go.userLanguageServer": true
+		"go.toolsManagement.autoUpdate": true,
+		"go.toolsManagement.checkForUpdates": "off"
 	},
-
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-ceintl.vscode-language-pack-ja",
 		"coenraads.bracket-pair-colorizer-2",
 		"shardulm94.trailing-spaces",
 		"golang.go"
-	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line if you want start specific services in your Docker Compose config.
-	// "runServices": [],
-
-	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
-	// "shutdownAction": "none",
-
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "apt-get update && apt-get install -y curl"
-	"postCreateCommand": "go install golang.org/x/tools/gopls@latest && go install github.com/go-delve/delve/cmd/dlv@latest && go install golang.org/x/lint/golint@latest && go install github.com/ramya-rao-a/go-outline@latest && go install github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest"
-
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	]
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,4 +4,5 @@ services:
     build:
       context: .
       target: dev
+    image: clubhook-backend_app_dev
     command: /bin/sh -c "while sleep 1000; do :; done"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,37 +1,7 @@
 version: '3.8'
 services:
-  # Update this to the name of the service you want to work with in your docker-compose.yml file
   app:
-    # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
-    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
-    # debugging) to execute as the user. Uncomment the next line if you want the entire 
-    # container to run as this user instead. Note that, on Linux, you may need to 
-    # ensure the UID and GID of the container user you create matches your local user. 
-    # See https://aka.ms/vscode-remote/containers/non-root for details.
-    #
-    # user: vscode
-
-    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
-    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
-    # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
-    # array). The sample below assumes your primary file is in the root of your project.
-    #
-    # build:
-    #   context: .
-    #   dockerfile: .devcontainer/Dockerfile
-
-    #volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      #- .:/workspace
-
-      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
-      # - /var/run/docker.sock:/var/run/docker.sock
-
-    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
-    # cap_add:
-    #   - SYS_PTRACE
-    # security_opt:
-    #   - seccomp:unconfined
-
-    # Overrides default command so things don't shut down after the process ends.
+    build:
+      context: .
+      target: dev
     command: /bin/sh -c "while sleep 1000; do :; done"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ FROM golang:1.16 AS dev
 WORKDIR /go/src/app
 COPY . .
 # 使用するモジュールのインストール
-RUN go install github.com/labstack/echo \
-  gorm.io/gorm && \
-  go install github.com/99designs/gqlgen@latest \
-  github.com/go-delve/delve/cmd/dlv@latest \
-  golang.org/x/tools/gopls@latest
+RUN go install github.com/labstack/echo && \
+  go install gorm.io/gorm && \
+  go install github.com/99designs/gqlgen@latest && \
+  go install github.com/go-delve/delve/cmd/dlv@latest && \
+  go install golang.org/x/tools/gopls@latest
 
 # ビルド用ステージ
 FROM golang:1.16 AS build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-# 2021/02/28最新version
-FROM golang:1.16.0
-
-# コンテナ内にディレクトリを作成
-RUN mkdir -p /go/src/github.com/kougakusai/clubhook-backend
-
-# コンテナログイン時のディレクトリを設定
-WORKDIR /go/src/github.com/kougakusai/clubhook-backend
-
-# ホストのファイルをコンテナにコピー
-ADD . /go/src/github.com/kougakusai/clubhook-backend
-
+# 開発用ステージ
+FROM golang:1.16 AS dev
+WORKDIR /go/src/app
+COPY . .
 # 使用するモジュールのインストール
-RUN go get github.com/labstack/echo && go get gorm.io/gorm && go get github.com/99designs/gqlgen
+RUN go install github.com/labstack/echo \
+  gorm.io/gorm && \
+  go install github.com/99designs/gqlgen@latest \
+  github.com/go-delve/delve/cmd/dlv@latest \
+  golang.org/x/tools/gopls@latest
+
+# ビルド用ステージ
+FROM golang:1.16 AS build
+WORKDIR /go/src/app
+# Herokuのrelease phaseでログを残すためにcurlを入れる
+RUN apt-get update && apt-get install curl
+COPY . .
+RUN go mod download && CGO_ENABLED=0 GOOS=linux go build -o main main.go
+
+# 実行用ステージ
+FROM scratch AS prod
+COPY --from=build /go/src/app/main /bin/main
+ENTRYPOINT ["/bin/main"]

--- a/README.md
+++ b/README.md
@@ -2,35 +2,44 @@
 
 https://clubhook-backend.herokuapp.com/
 
-## Getting Started
+## Requirement
 
-Docker(docker-compose)で開発環境を用意する場合はgit cloneでソースを取得。
+* Docker
 
-#### Clone Repository
+* docker-compose
 
-```
-$ git clone https://github.com/kougakusai/clubhook-backend.git
-$ cd clubhook-backend
-```
+## Usage
 
-#### Docker(docker-compose)で実行する場合
+ローカルでは、docker-composeでコンテナを立ち上げることでサーバが起動します。
 
 ```
 $ docker-compose build
-$ docker-compose up -d
-
-$ docker-compose exec app go run main.go
-# Access to "localhost:8000"
-
-$ docker-compose exec app /bin/bash
-$ go run main.go
-# Access to "localhost:8000"
-$ exit
-
-$ docker-compose down
+$ docker-compose up
 ```
 
-#### VSCodeでDevContainerを起動し開発する場合
-VSCodeを起動後、ウインドウ左下端の緑の部分をクリック。
-メニューから「Remote-Containers:Open Folder in Container...」をクリック。
-git cloneしたディレクトリを選択。
+#### 注意
+
+初回ビルド時などに、appコンテナがpostgresコンテナよりも先に起動し、
+データベースとのコネクションエラーが起きることがあります。
+
+その場合は一度コンテナを`Ctrl+C`などで停止して、
+もう一度`docker-compose up`でコンテナを起動してください。
+
+## Contribution
+
+VSCode Remote Containers向けの設定を用意していますので、
+Visual Studio Codeで開発することをおすすめします。
+
+### Visual Studio Codeで開発用コンテナを起動する方法
+
+* Visual Studio Codeを起動後、ウインドウ左下端の緑の部分をクリック。
+
+* メニューから「Remote-Containers:Open Folder in Container...」をクリック。
+
+#### 注意
+
+`docker-compose build`を行った後に開発用コンテナを起動しようとするとエラーが起きます。
+その場合は`Rebuild Container`で開発用コンテナを再ビルドしてください。
+
+このエラーを回避するため、開発中の動作確認はdocker-composeを使用せず、
+Visual Studio Codeのターミナルから`go run main.go`でサーバを起動することをおすすめします。

--- a/README.md
+++ b/README.md
@@ -36,10 +36,3 @@ Visual Studio Codeで開発することをおすすめします。
 
 * メニューから「Remote-Containers:Open Folder in Container...」をクリック。
 
-#### 注意
-
-`docker-compose build`を行った後に開発用コンテナを起動しようとするとエラーが起きます。
-その場合は`Rebuild Container`で開発用コンテナを再ビルドしてください。
-
-このエラーを回避するため、開発中の動作確認はdocker-composeを使用せず、
-Visual Studio Codeのターミナルから`go run main.go`でサーバを起動することをおすすめします。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,3 @@ services:
       - postgres
     ports:
       - "8000:8000"
-    # volumes:
-      # - .:/go/src/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     build:
       context: .
       target: prod
+    image: clubhook-backend_app_prod
     depends_on:
       - postgres
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,12 @@ services:
       - POSTGRES_PASSWORD=password
       - POSTGRES_DB=example_db
   app:
-    build: .
+    build:
+      context: .
+      target: prod
     depends_on:
       - postgres
-    tty: true
     ports:
       - "8000:8000"
-    environment:
-      - GOPATH=/go
-    volumes:
-      - .:/go/src/github.com/kougakusai/clubhook-backend
+    # volumes:
+      # - .:/go/src/app


### PR DESCRIPTION
# 変更
* Dockerfileを書き換え、マルチステージビルドを採用
* docker-composeを書き換え、`docker-compose up`ですぐにサーバを起動
* .devcontainer/以下を書き換え、VSCodeの開発環境の設定を変更

# 詳細
## マルチステージビルド
Dockerイメージを3つのステージに分けた。
* `dev`：VSCodeの開発コンテナ用。開発時に利用するツールを`go install`している。
* `build`：ビルド用。Herokuでログを出すために`curl`を入れた。
* `prod`：本番用。`build`ステージで生成した実行ファイルだけを入れ、軽量化した。
## docker-compose
`docker-compose up`でサーバが立ち上がるようにした。ローカルで動作確認するため。
## VSCodeの設定
`.go`ファイルのインデントをタブに指定した。また、不要な設定が多かったので削除した。

# バグ
`docker-compose build`で作られるイメージは`prod`だが、VSCode Remote Containersのイメージは`dev`なので、
`docker-compose build`のイメージが残っている状態でVSCodeを開くとエラーになってしまう。

VSCodeで再ビルドすれば解消するが、そもそも`docker-compose up`でサーバを起動するより、
VSCodeのターミナルで`go run`する方が楽なので、修正を待たずにマージしても問題ないと判断した。